### PR TITLE
Added python 3 support.

### DIFF
--- a/rewrite.py
+++ b/rewrite.py
@@ -3,6 +3,7 @@ import socket
 import sys
 import threading
 import logging
+import locale
 
 import blessings
 import pity
@@ -10,6 +11,7 @@ from findcursor import get_cursor_position
 
 # version 1: record sequences, guess how many lines to go back up
 terminal = blessings.Terminal()
+encoding = locale.getdefaultlocale()[1]
 
 outputs = [b'']
 
@@ -29,6 +31,7 @@ def save():
 
 def count_lines(msg, width):
     """Number of lines msg would move cursor down"""
+    msg = msg.decode(encoding)
     return sum([max(0, (len(line) - 1) // width) + 1
                 for line in msg.split('\n')]) - 1
 


### PR DESCRIPTION
In the `count_lines` function we interpret the bytes returned by
`os.read` as being encoded using the default locale.  This seems to me
like a reasonable enough assumption to make.

As far as I can tell, this was the only thing preventing python3 from working.
