### PR TITLE
Rewrite count line and testing tools for it

### DIFF
--- a/input_with_colours.txt
+++ b/input_with_colours.txt
@@ -1,0 +1,6 @@
+[0;31m---------------------------------------------------------------------------[0m
+[0;31mNameError[0m                                 Traceback (most recent call last)
+[0;32m<ipython-input-1-60b725f10c9c>[0m in [0;36m<module>[0;34m()[0m
+[0;32m----> 1[0;31m [0ma[0m[0;34m[0m[0m
+[0m
+[0;31mNameError[0m: name 'a' is not defined

--- a/input_with_colours.txt
+++ b/input_with_colours.txt
@@ -1,6 +1,6 @@
-[0;31m---------------------------------------------------------------------------[0m
-[0;31mNameError[0m                                 Traceback (most recent call last)
-[0;32m<ipython-input-1-60b725f10c9c>[0m in [0;36m<module>[0;34m()[0m
-[0;32m----> 1[0;31m [0ma[0m[0;34m[0m[0m
-[0m
-[0;31mNameError[0m: name 'a' is not defined
+\x1b[0;31m---------------------------------------------------------------------------\x1b[0m
+\x1b[0;31mNameError\x1b[0m                                 Traceback (most recent call last)
+\x1b[0;32m<ipython-input-1-60b725f10c9c>\x1b[0m in \x1b[0;36m<module>\x1b[0;34m()\x1b[0m
+\x1b[0;32m----> 1\x1b[0;31m \x1b[0ma\x1b[0m\x1b[0;34m\x1b[0m\x1b[0m
+\x1b[0m
+\x1b[0;31mNameError\x1b[0m: name 'a' is not defined

--- a/py_logger.py
+++ b/py_logger.py
@@ -1,0 +1,44 @@
+#!/usr/bin/env python
+
+"""
+py_logger
+----------------------------------
+
+Write a log of what's going on in a python terminal to see the actual bytes
+decoded.
+
+Use it from the command line: `python py_logger.py ipython`
+Use it from another python script:
+    `from py_logger import run`
+    `run(['ipython'])
+"""
+
+from __future__ import unicode_literals
+import os
+import sys
+import pity
+
+log = open('output.log', 'w')
+
+
+def master_read(fd):
+    """Read the output of a terminal writing a log in the middle.
+    Args:
+        fd: File descriptor being read.
+    """
+    data = os.read(fd, 1024)
+    log.write(data)
+    return data
+
+
+def run(argv):
+    """Spawn a process with master read writing a log file in between.
+    Args:
+        argv: Additional arguments after `python py_logger` command
+    """
+    pity.spawn(argv,
+               master_read=master_read,
+               handle_window_size=True)
+
+if __name__ == '__main__':
+    run(sys.argv[1:])

--- a/rewrite.py
+++ b/rewrite.py
@@ -50,6 +50,7 @@ def count_lines(msg, width):
 def _line_len(line):
     """Calculate len of a string without colour escape characters."""
     line_without_colours = re.sub("\x1b[[]0(;\d\d)?m", "", line)
+    line_without_colours = line_without_colours.strip("\n")
     return len(line_without_colours)
 
 

--- a/rlundo.py
+++ b/rlundo.py
@@ -1,4 +1,13 @@
 #!/usr/bin/env python
+
+"""
+rlundo
+----------------------------------
+
+Start a repl with undo feature.
+"""
+
+from __future__ import unicode_literals
 import sys
 
 from rlundoable import modify_env_with_modified_rl

--- a/test_rewrite.py
+++ b/test_rewrite.py
@@ -5,6 +5,7 @@ import socket
 import textwrap
 import time
 import unittest
+import nose
 
 import terminal_dsl
 import tmux
@@ -145,6 +146,11 @@ class TestRewriteHelpers(unittest.TestCase):
         self.assertEqual(rewrite.count_lines("1234\n123456", 4), 2)
         self.assertEqual(rewrite.count_lines("1234\n123456", 10), 1)
         self.assertEqual(rewrite.count_lines("> undo\r\n> 1\r\n1\r\n", 10), 3)
+
+        with open("input_with_colours.txt", "r") as f:
+            data = f.read()
+
+        self.assertEqual(rewrite.count_lines(data, 80), 6)
 
     def test_linesplit(self):
         self.assertEqual(rewrite.linesplit(["1234", "123456"], 4),
@@ -560,3 +566,6 @@ class TestUndoScenario(unittest.TestCase):
         ~      ~
         +------+
         """)
+
+if __name__ == '__main__':
+    nose.run(defaultTest=__name__)

--- a/test_rewrite.py
+++ b/test_rewrite.py
@@ -149,7 +149,6 @@ class TestRewriteHelpers(unittest.TestCase):
 
         with open("input_with_colours.txt", "r") as f:
             data = f.read()
-
         self.assertEqual(rewrite.count_lines(data, 80), 6)
 
     def test_linesplit(self):
@@ -157,6 +156,19 @@ class TestRewriteHelpers(unittest.TestCase):
                          ["1234", "1234", "56"])
         self.assertEqual(rewrite.linesplit(["1234", "123456"], 10),
                          ["1234", "123456"])
+
+    def test_line_len(self):
+        self.assertEqual(rewrite._line_len("1234"), 4)
+        self.assertEqual(rewrite._line_len("1234\n"), 4)
+        self.assertEqual(rewrite._line_len("\x1b[0;32m1234"), 4)
+        self.assertEqual(rewrite._line_len("\x1b[0m1234"), 4)
+
+    def test_line_resizes(self):
+        self.assertEqual(rewrite._line_resizes("1234", 4), 1)
+        self.assertEqual(rewrite._line_resizes("1234", 3), 2)
+        self.assertEqual(rewrite._line_resizes("1234", 2), 2)
+        self.assertEqual(rewrite._line_resizes("1234", 1), 4)
+        self.assertEqual(rewrite._line_resizes("\x1b[0;32m1234", 2), 2)
 
 
 class TestRunWithTmux(unittest.TestCase):

--- a/test_rlundo.py
+++ b/test_rlundo.py
@@ -1,0 +1,205 @@
+#!/usr/bin/env python
+
+"""
+test_rlundo
+----------------------------------
+
+Integration test for undo features implemented in rlundo. It sends commands
+to an open tmux terminal using 'undo' and checks that the output is the
+expected one.
+
+To create new tests you may one to use py_logger to capture decoded bytes from
+a python terminal and see how they look:
+    `python py_logger.py ipython` or
+    `python py_logger.py python`
+
+For some reason, the formatting is not handled properly by tmux.visible()
+method and thus the decode logging captured may differ, it has to be used only
+as a guide.
+"""
+
+from __future__ import unicode_literals
+import unittest
+import nose
+import sys
+
+import tmux
+
+
+class ActualUndo(tmux.TmuxPane):
+
+    """
+    Run a tmux pane instance to start a repl, send commands, use undo and check
+    the expected output.
+
+    ActualUndo is better used within the context manager and tmux module can be
+    used to send commands:
+
+        with ActualUndo(80, 30) as t:
+            tmux.send_command(t, "print 'hi'", prompt=expected_prompt)
+            output = tmux.visible(t)
+
+    If you want to see what's going on while sending commands from a repl, you
+    can do that by oppening a session with the __enter__() method and
+    attaching a tmux session to it.
+
+        (in ipython)
+        from test_rlundo import ActualUndo
+        w = ActualUndo(50, 30).__enter__()
+
+        (in another terminal)
+        tmux attach
+
+        (in ipython)
+        w.send_keys("a = 1")
+        w.send_keys("a")
+
+        In the other terminal you will see the session inputs and outputs.
+    """
+
+    def bash_config_contents(self):
+        python_env = sys.executable
+        return """
+        export PS1='$'
+        alias irb="python rlundo.py /usr/bin/irb"
+        alias ipy="{} rlundo.py ipython"
+        """.format(python_env)
+
+    def __enter__(self):
+        """Initialize a pane with an undo scenario.
+
+        undo schenarios always start by calling python rewrite.py
+
+        >>> with ActualUndo(30, 10) as t:
+        ...     tmux.send_command(t, 'echo hello')
+        ...     print(tmux.visible_after_prompt(t, expected=u'$'))
+        [u'$echo hello', u'hello', u'$']
+        """
+        return tmux.TmuxPane.__enter__(self)
+
+
+class TestUndoableIpythonWithTmux(unittest.TestCase):
+
+    """Use ActualUndo and tmux to send commands to an IPython repl and check
+    undo feature rewrite the terminal as expected.
+    """
+
+    def ipy_in_formatted(self, num):
+        """Build ipython "In" prompt with formatting.
+
+        For some reason tmux doesn't deal with formatting in the same way that
+        normal ipython does, the proper ipython line for prompt is included as
+        a comment below."""
+        # return u'\x1b[34mIn [\x1b[1m{}\x1b[0;34m]:'.format(num)
+        return u'\x1b[34mIn [\x1b[1m{}\x1b[0m]:'.format(num)
+
+    def ipy_out_formatted(self, num):
+        """Build ipython "Out" prompt with formatting.
+
+        For some reason tmux doesn't deal with formatting in the same way that
+        normal ipython does, the proper ipython line for prompt is included as
+        a comment below."""
+        # return u'\x1b[31mOut[\x1b[1m{}\x1b[0;34m]:'.format(num)
+        return u'\x1b[31mOut[\x1b[1m{}\x1b[0m]:'.format(num)
+
+    def ipy_new_l_formatted(self):
+        """Build ipython new line in the same "In" prompt with formatting.
+
+        For some reason tmux doesn't deal with formatting in the same way that
+        normal ipython does, the proper ipython line for prompt is included as
+        a comment below."""
+        # return u'\x1b[34m   ...: \x1b[0m'
+        return u'\x1b[34m   ...: \x1b[39m'
+
+    def ipy_in(self, num):
+        """Build ipython "In" prompt without formatting."""
+        return u'In [{}]:'.format(num)
+
+    def ipy_out(self, num):
+        """Build ipython "Out" prompt without formatting."""
+        return u'Out[{}]:'.format(num)
+
+    def ipy_new_l(self):
+        """Build ipython new line inside an "In" prompt without formatting."""
+        return u'   ...:'
+
+    # @unittest.skip("skip")
+    def test_simple(self):
+        """Test sending commands and reading formatted output with tmux."""
+        with ActualUndo(80, 30) as t:
+            tmux.send_command(t, 'ipy', prompt=self.ipy_in_formatted(1))
+            tmux.send_command(t, 'a = 1', prompt=self.ipy_in_formatted(2))
+            tmux.send_command(t, 'a', prompt=self.ipy_in_formatted(3))
+            tmux.send_command(t, 'def foo():',
+                              prompt=self.ipy_new_l_formatted())
+            tmux.send_command(t, 'print "hi"',
+                              prompt=self.ipy_new_l_formatted())
+            tmux.send_command(t, ' ', prompt=self.ipy_in_formatted(4))
+            output = tmux.visible(t)
+            lines = [self.ipy_in_formatted(1) + ' \x1b[39ma = 1',
+                     self.ipy_in_formatted(2) + ' \x1b[39ma',
+                     self.ipy_out_formatted(2) + ' \x1b[39m1',
+                     self.ipy_in_formatted(3) + ' \x1b[39mdef foo():',
+                     self.ipy_new_l_formatted() + '    print "hi"',
+                     self.ipy_new_l_formatted() + '',
+                     self.ipy_in_formatted(4)]
+            self.assertEqual(output[-7:], lines)
+
+    # @unittest.skip("skip")
+    def test_undo_simple(self):
+        """Test undoing one liner command in ipython."""
+        with ActualUndo(80, 30) as t:
+
+            # type some commands
+            tmux.send_command(t, 'ipy', prompt=self.ipy_in_formatted(1))
+            tmux.send_command(t, 'a = 1', prompt=self.ipy_in_formatted(2))
+            tmux.send_command(t, 'a', prompt=self.ipy_in_formatted(3))
+            output = tmux.visible_without_formatting(t)
+            lines = [self.ipy_in(1) + ' a = 1',
+                     self.ipy_in(2) + ' a',
+                     self.ipy_out(2) + ' 1',
+                     self.ipy_in(3)]
+            self.assertEqual(output[-4:], lines)
+
+            # undo
+            tmux.send_command(t, 'undo', prompt=self.ipy_in_formatted(2))
+            output = tmux.visible_without_formatting(t)
+            self.assertEqual(output[-2:],
+                             lines[:1] + [self.ipy_in(2)])
+
+    # @unittest.skip("skip")
+    def test_undo_multiple_input_lines(self):
+        """Test udoing a line of a multiple lines command in ipython."""
+        with ActualUndo(80, 30) as t:
+
+            # type some commands
+            tmux.send_command(t, 'ipy', prompt=self.ipy_in_formatted(1))
+            tmux.send_command(t, 'def foo():',
+                              prompt=self.ipy_new_l_formatted())
+            tmux.send_command(t, 'print "hi"',
+                              prompt=self.ipy_new_l_formatted())
+            tmux.send_command(t, ' ', prompt=self.ipy_in_formatted(2))
+            tmux.send_command(t, 'foo()', prompt=self.ipy_in_formatted(3))
+            output = tmux.visible_without_formatting(t)
+            lines = [self.ipy_in(1) + ' def foo():',
+                     self.ipy_new_l() + '     print "hi"',
+                     self.ipy_new_l() + '',
+                     self.ipy_in(2) + ' foo()',
+                     'hi',
+                     self.ipy_in(3)]
+            self.assertEqual(output[-6:], lines)
+
+            # undo
+            tmux.send_command(t, 'undo', prompt=self.ipy_in_formatted(2))
+            output = tmux.visible_without_formatting(t)
+            self.assertEqual(output[-4:], lines[:3] + [self.ipy_in(2)])
+
+            # undo again
+            tmux.send_command(t, 'undo', prompt=self.ipy_new_l_formatted())
+            output = tmux.visible_without_formatting(t)
+            self.assertEqual(output[-3:], lines[:2] + [self.ipy_new_l()])
+
+
+if __name__ == '__main__':
+    nose.run(defaultTest=__name__)
+    # unittest.main()

--- a/tmux.py
+++ b/tmux.py
@@ -25,6 +25,10 @@ def visible(pane):
     return pane.tmux('capture-pane', '-ep').stdout
 
 
+def visible_without_formatting(pane):
+    return pane.tmux('capture-pane', '-p').stdout
+
+
 def visible_after_prompt(pane, expected=u'$', interval=.1, max=1):
     """Return the visible region once expected is found on last line"""
     t0 = time.time()
@@ -148,8 +152,7 @@ class TmuxPane(object):
         return """"""
 
     def bash_config_contents(self):
-        return """export PS1='$'
-    """
+        return """export PS1='$'"""
 
     def tempfile(self, contents):
         tmp = tempfile.NamedTemporaryFile()

--- a/undoableipython.py
+++ b/undoableipython.py
@@ -6,9 +6,14 @@ undoableipython
 
 This module contains a replacement for the
 TerminalInteractiveShell.raw_input_original method that can be found in
-IPython source code. The replacement implements undoable feature.
+IPython source code. The replacement implements undoable feature for ipython
+without rewriting the terminal (you will see the history of written statements
+but the last statement will be undone).
+
+Use it from the command line: `python undoableipython.py`
 """
 
+from __future__ import unicode_literals
 import os
 import sys
 from IPython.utils import py3compat
@@ -95,7 +100,11 @@ def patch_ipython():
 
 
 def rl_is_ipython(rl_path):
-    """Check if the terminal to be opened is ipython."""
+    """Check if the terminal to be opened is ipython.
+
+    Args:
+        rl_path: Path of interpreter being called.
+    """
     return os.path.basename(rl_path) == "ipython"
 
 


### PR DESCRIPTION
Here it goes. This was about rewriting rewrite.count_lines() to take into account text formatting. Tests for this were added in test_rewrite and test_rlundo is the highest level test for it. We've added some tools to take a look at the terminal output when running ipython or other repls and docstrings have examples on how to use them.
