### PR TITLE
Use lock when writing to terminal.

### DIFF
--- a/pity.py
+++ b/pity.py
@@ -6,10 +6,39 @@ import select
 import signal
 import sys
 import termios
+import threading
 import tty
 import logging
 logging.basicConfig(filename='debug.log', level=logging.INFO)
 from termhelpers import Nonblocking
+
+class TerminalLock(object):
+    """Lock that can be over-released
+
+    Every master write to the pty should be followed
+    by a pty write to the terminal, but not every pty write
+    is initiated by a master write."""
+
+    def __init__(self):
+        self.rlock = threading.RLock()
+        self.lock_count = 0
+
+    def acquire(self):
+        self.rlock.acquire()
+        self.lock_count += 1
+
+    def release(self):
+        if self.lock_count > 0:
+            self.rlock.release()
+            self.lock_count -= 1
+
+    def __enter__(self):
+        return self.rlock.__enter__()
+
+    def __exit__(self, *args, **kwargs):
+        return self.rlock.__exit__(*args, **kwargs)
+
+
 
 CHILD = pty.CHILD
 STDIN_FILENO = pty.STDIN_FILENO
@@ -49,7 +78,8 @@ def fork(handle_window_size=False):
 def openpty():
     return pty.openpty()
 
-def _copy(master_fd, master_read=pty._read, stdin_read=pty._read):
+def _copy(master_fd, master_read=pty._read, stdin_read=pty._read,
+          terminal_output_lock=None):
     """Parent copy loop.
     Copies
             pty master -> standard output   (master_read)
@@ -68,6 +98,9 @@ def _copy(master_fd, master_read=pty._read, stdin_read=pty._read):
                 fds.remove(master_fd)
             else:
                 os.write(STDOUT_FILENO, data)
+                if terminal_output_lock is not None:
+                    terminal_output_lock.release()
+
         if STDIN_FILENO in rfds:
             logging.debug('stdin is ready, dealing...')
 
@@ -81,10 +114,13 @@ def _copy(master_fd, master_read=pty._read, stdin_read=pty._read):
                     if not data:
                         fds.remove(STDIN_FILENO)
                     else:
+                        if terminal_output_lock is not None:
+                            terminal_output_lock.acquire()
                         pty._writen(master_fd, data)
             logging.debug('done dealing with stdin')
 
-def spawn(argv, master_read=pty._read, stdin_read=pty._read, handle_window_size=False):
+def spawn(argv, master_read=pty._read, stdin_read=pty._read, handle_window_size=False,
+          terminal_output_lock=None):
     # copied from pty.py, with modifications
     # note that it references a few private functions - would be nice to not
     # do that, but you know
@@ -108,7 +144,7 @@ def spawn(argv, master_read=pty._read, stdin_read=pty._read, handle_window_size=
 
     while True:
         try:
-            _copy(master_fd, master_read, stdin_read)
+            _copy(master_fd, master_read, stdin_read, terminal_output_lock)
         except OSError as e:
             if e.errno == errno.EINTR:
                 continue

--- a/rewrite.py
+++ b/rewrite.py
@@ -24,10 +24,11 @@ terminal = blessings.Terminal()
 encoding = locale.getdefaultlocale()[1]
 
 outputs = [b'']
+terminal_output_lock = pity.TerminalLock()
+
 
 logger = logging.getLogger(__name__)
 logging.basicConfig(filename='example.log', level=logging.INFO)
-
 
 def write(data):
     sys.stdout.write(data)
@@ -73,6 +74,10 @@ HISTORY_BROKEN_MSG = '#<---History contiguity broken by rewind--->'
 
 
 def restore():
+    with terminal_output_lock:
+        _restore()
+
+def _restore():
     logger.debug('full output stack: %r' % (outputs, ))
     lines_between_saves = outputs.pop() if outputs else ''
     lines_after_save = outputs.pop() if outputs else ''
@@ -140,7 +145,8 @@ def master_read(fd):
 def run(argv):
     pity.spawn(argv,
                master_read=master_read,
-               handle_window_size=True)
+               handle_window_size=True,
+               terminal_output_lock=terminal_output_lock)
 
 
 def run_with_listeners(args):

--- a/undoablepython.py
+++ b/undoablepython.py
@@ -5,7 +5,6 @@ import logging
 import os
 import socket
 import sys
-import time
 from functools import partial
 
 # read about copy-on-write for Python processes - I feel like I've heard
@@ -60,7 +59,6 @@ def readline(prompt):
         except KeyboardInterrupt:
             s = 'undo'
         if s == 'undo':
-            time.sleep(.001) # race condition, see issue #29
             restore()
             readline.on_undo()
         read_fd, write_fd = os.pipe()


### PR DESCRIPTION
- Better fix for #29
- Breaks undo after commands that read input without echoing it to terminal (e.g. Python's getpass)
